### PR TITLE
added API for extending and overriding the default codec

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,3 +8,5 @@ exports.Decoder = require("./lib/decoder").Decoder;
 
 exports.createEncodeStream = require("./lib/encode-stream").createEncodeStream;
 exports.createDecodeStream = require("./lib/decode-stream").createDecodeStream;
+
+exports.codec = require("./ext-preset").preset;

--- a/index.js
+++ b/index.js
@@ -9,4 +9,4 @@ exports.Decoder = require("./lib/decoder").Decoder;
 exports.createEncodeStream = require("./lib/encode-stream").createEncodeStream;
 exports.createDecodeStream = require("./lib/decode-stream").createDecodeStream;
 
-exports.codec = require("./ext-preset").preset;
+exports.codec = require("./lib/ext-preset").preset;

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -5,3 +5,5 @@ exports.decode = require("./decode").decode;
 
 exports.Encoder = require("./encoder").Encoder;
 exports.Decoder = require("./decoder").Decoder;
+
+exports.codec = require("./ext-preset").preset;

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -49,3 +49,9 @@ Ext.prototype.getExtUnpacker = function(type) {
     return new ExtBuffer(buffer, type);
   }
 };
+
+Ext.prototype.reset = function () {
+  this.extPackers = {};
+  this.extUnpackers = [];
+  this.extEncoderList = undefined;
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
     "concat-stream": "^1.5.1",
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
+    "msgpack": "^1.0.2",
+    "msgpack-js": "^0.3.0",
+    "msgpack-js-v5": "^0.3.0-v5",
+    "msgpack-unpack": "^2.1.1",
     "msgpack.codec": "git+https://github.com/kawanet/msgpack-javascript.git#msgpack.codec",
+    "msgpack5": "^3.3.0",
+    "notepack": "0.0.2",
     "uglify-js": "^2.6.1",
     "zuul": "^3.8.0"
   },


### PR DESCRIPTION
This change makes it easy for API consumers to extend or override the default codec.

Edit:
I have no idea why the Travis checks are failing. All tests pass when I run `npm run test` on my computer.