### PR TITLE
exposed codec API

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,13 +239,13 @@ msgpack.encode(data, {codec: codec});
 
 The first argument of `addExtPacker` and `addExtUnpacker` should be an integer within the range of 0 and 127 (0x0 and 0x7F). `myClassPacker` is a function that accepts an instance of `MyClass`, and should return a buffer representing that instance. `myClassUnpacker` is the opposite: it accepts a buffer and should return an instance of `MyClass`.
 
-You can also pass the `{codec: codec}` option to new instances of `msgpack.Decoder(options)`, `msgpack.Encoder(options)`, `msgpack.createEncodeStream(options)`, and `msgpack.createDecodeStream(options)`.
-
-If you pass an array of functions to `addExtPacker` or `addExtUnpacker`, the value to be encoder/decoded will pass through each one in order. This allows you to do things like this:
+If you pass an array of functions to `addExtPacker` or `addExtUnpacker`, the value to be encoded/decoded will pass through each one in order. This allows you to do things like this:
 
 ```js
 codec.addExtPacker(0x00, Date, [Number, msgpack.encode]);
 ```
+
+You can also pass the `codec` option to `msgpack.Decoder(options)`, `msgpack.Encoder(options)`, `msgpack.createEncodeStream(options)`, and `msgpack.createDecodeStream(options)`.
 
 If you wish to modify the default built-in codec, you can access it at `msgpack.codec.preset`.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ var decodeStream = msgpack.createDecodeStream();
 readStream.pipe(decodeStream).on("data", console.warn);
 ```
 
+### Custom Codecs
+
+```js
+var msgpack = require("msgpack-lite");
+
+var codec = msgpack.createCodec();
+codec.addExtPacker(0x3F, MyClass, myClassPacker);
+codec.addExtUnpacker(0x3F, myClassUnpacker);
+msgpack.encode(data, {codec: codec});
+```
+
+The first argument of `addExtPacker` and `addExtUnpacker` should be an integer within the range of 0 and 127 (0x0 and 0x7F). `myClassPacker` is a function that accepts an instance of `MyClass`, and should return a buffer representing that instance. `myClassUnpacker` is the opposite: it accepts a buffer and should return an instance of `MyClass`.
+
+You can also pass the `{codec: codec}` option to new instances of `msgpack.Decoder(options)`, `msgpack.Encoder(options)`, `msgpack.createEncodeStream(options)`, and `msgpack.createDecodeStream(options)`.
+
+If you pass an array of functions to `addExtPacker` or `addExtUnpacker`, the value to be encoder/decoded will pass through each one in order. This allows you to do things like this:
+
+```js
+codec.addExtPacker(0x00, Date, [Number, msgpack.encode]);
+```
+
+If you wish to modify the default built-in codec, you can access it at `msgpack.codec.preset`.
+
 ### Command Line Interface
 
 A CLI tool bin/msgpack converts data stream from JSON to MessagePack and vice versa.

--- a/README.md
+++ b/README.md
@@ -60,29 +60,6 @@ var decodeStream = msgpack.createDecodeStream();
 readStream.pipe(decodeStream).on("data", console.warn);
 ```
 
-### Custom Codecs
-
-```js
-var msgpack = require("msgpack-lite");
-
-var codec = msgpack.createCodec();
-codec.addExtPacker(0x3F, MyClass, myClassPacker);
-codec.addExtUnpacker(0x3F, myClassUnpacker);
-msgpack.encode(data, {codec: codec});
-```
-
-The first argument of `addExtPacker` and `addExtUnpacker` should be an integer within the range of 0 and 127 (0x0 and 0x7F). `myClassPacker` is a function that accepts an instance of `MyClass`, and should return a buffer representing that instance. `myClassUnpacker` is the opposite: it accepts a buffer and should return an instance of `MyClass`.
-
-You can also pass the `{codec: codec}` option to new instances of `msgpack.Decoder(options)`, `msgpack.Encoder(options)`, `msgpack.createEncodeStream(options)`, and `msgpack.createDecodeStream(options)`.
-
-If you pass an array of functions to `addExtPacker` or `addExtUnpacker`, the value to be encoder/decoded will pass through each one in order. This allows you to do things like this:
-
-```js
-codec.addExtPacker(0x00, Date, [Number, msgpack.encode]);
-```
-
-If you wish to modify the default built-in codec, you can access it at `msgpack.codec.preset`.
-
 ### Command Line Interface
 
 A CLI tool bin/msgpack converts data stream from JSON to MessagePack and vice versa.
@@ -248,6 +225,29 @@ Type|Object|Type|Object
 0x0F|Number|0x1F|
 
 Other extension types are mapped to internal ExtBuffer object.
+
+### Custom Extension Types (Codecs)
+
+```js
+var msgpack = require("msgpack-lite");
+
+var codec = msgpack.createCodec();
+codec.addExtPacker(0x3F, MyClass, myClassPacker);
+codec.addExtUnpacker(0x3F, myClassUnpacker);
+msgpack.encode(data, {codec: codec});
+```
+
+The first argument of `addExtPacker` and `addExtUnpacker` should be an integer within the range of 0 and 127 (0x0 and 0x7F). `myClassPacker` is a function that accepts an instance of `MyClass`, and should return a buffer representing that instance. `myClassUnpacker` is the opposite: it accepts a buffer and should return an instance of `MyClass`.
+
+You can also pass the `{codec: codec}` option to new instances of `msgpack.Decoder(options)`, `msgpack.Encoder(options)`, `msgpack.createEncodeStream(options)`, and `msgpack.createDecodeStream(options)`.
+
+If you pass an array of functions to `addExtPacker` or `addExtUnpacker`, the value to be encoder/decoded will pass through each one in order. This allows you to do things like this:
+
+```js
+codec.addExtPacker(0x00, Date, [Number, msgpack.encode]);
+```
+
+If you wish to modify the default built-in codec, you can access it at `msgpack.codec.preset`.
 
 ### Repository
 

--- a/index.js
+++ b/index.js
@@ -8,3 +8,6 @@ exports.Decoder = require("./lib/decoder").Decoder;
 
 exports.createEncodeStream = require("./lib/encode-stream").createEncodeStream;
 exports.createDecodeStream = require("./lib/decode-stream").createDecodeStream;
+
+exports.createCodec = require("./lib/ext").createCodec;
+exports.codec = require("./lib/codec").codec;

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -5,3 +5,6 @@ exports.decode = require("./decode").decode;
 
 exports.Encoder = require("./encoder").Encoder;
 exports.Decoder = require("./decoder").Decoder;
+
+exports.createCodec = require("./ext").createCodec;
+exports.codec = require("./codec").codec;

--- a/lib/codec.js
+++ b/lib/codec.js
@@ -1,0 +1,3 @@
+exports.codec = {
+	preset: require("./ext-preset").preset
+};

--- a/lib/decode-buffer.js
+++ b/lib/decode-buffer.js
@@ -2,11 +2,13 @@
 
 exports.DecodeBuffer = DecodeBuffer;
 
+var preset = require("./ext-preset").preset;
 var DEFAULT_OPTIONS = {};
 
 function DecodeBuffer(options) {
   if (!(this instanceof DecodeBuffer)) return new DecodeBuffer(options);
   this.options = options || DEFAULT_OPTIONS;
+  this.codec = this.options.codec || preset;
 }
 
 DecodeBuffer.prototype.push = Array.prototype.push;

--- a/lib/encode-buffer.js
+++ b/lib/encode-buffer.js
@@ -2,6 +2,7 @@
 
 exports.EncodeBuffer = EncodeBuffer;
 
+var preset = require("./ext-preset").preset;
 var MIN_BUFFER_SIZE = 2048;
 var MAX_BUFFER_SIZE = 65536;
 var DEFAULT_OPTIONS = {};
@@ -9,6 +10,7 @@ var DEFAULT_OPTIONS = {};
 function EncodeBuffer(options) {
   if (!(this instanceof EncodeBuffer)) return new EncodeBuffer(options);
   this.options = options || DEFAULT_OPTIONS;
+  this.codec = this.options.codec || preset;
 }
 
 EncodeBuffer.prototype.push = function(chunk) {

--- a/lib/ext-preset.js
+++ b/lib/ext-preset.js
@@ -12,33 +12,33 @@ var ERROR_COLUMNS = {name: 1, message: 1, stack: 1, columnNumber: 1, fileName: 1
 init();
 
 function init() {
-  preset.addExtPacker(0x0E, Error, join(packError, encode));
-  preset.addExtPacker(0x01, EvalError, join(packError, encode));
-  preset.addExtPacker(0x02, RangeError, join(packError, encode));
-  preset.addExtPacker(0x03, ReferenceError, join(packError, encode));
-  preset.addExtPacker(0x04, SyntaxError, join(packError, encode));
-  preset.addExtPacker(0x05, TypeError, join(packError, encode));
-  preset.addExtPacker(0x06, URIError, join(packError, encode));
+  preset.addExtPacker(0x0E, Error, [packError, encode]);
+  preset.addExtPacker(0x01, EvalError, [packError, encode]);
+  preset.addExtPacker(0x02, RangeError, [packError, encode]);
+  preset.addExtPacker(0x03, ReferenceError, [packError, encode]);
+  preset.addExtPacker(0x04, SyntaxError, [packError, encode]);
+  preset.addExtPacker(0x05, TypeError, [packError, encode]);
+  preset.addExtPacker(0x06, URIError, [packError, encode]);
 
-  preset.addExtUnpacker(0x0E, join(decode, unpackError(Error)));
-  preset.addExtUnpacker(0x01, join(decode, unpackError(EvalError)));
-  preset.addExtUnpacker(0x02, join(decode, unpackError(RangeError)));
-  preset.addExtUnpacker(0x03, join(decode, unpackError(ReferenceError)));
-  preset.addExtUnpacker(0x04, join(decode, unpackError(SyntaxError)));
-  preset.addExtUnpacker(0x05, join(decode, unpackError(TypeError)));
-  preset.addExtUnpacker(0x06, join(decode, unpackError(URIError)));
+  preset.addExtUnpacker(0x0E, [decode, unpackError(Error)]);
+  preset.addExtUnpacker(0x01, [decode, unpackError(EvalError)]);
+  preset.addExtUnpacker(0x02, [decode, unpackError(RangeError)]);
+  preset.addExtUnpacker(0x03, [decode, unpackError(ReferenceError)]);
+  preset.addExtUnpacker(0x04, [decode, unpackError(SyntaxError)]);
+  preset.addExtUnpacker(0x05, [decode, unpackError(TypeError)]);
+  preset.addExtUnpacker(0x06, [decode, unpackError(URIError)]);
 
-  preset.addExtPacker(0x0A, RegExp, join(packRegExp, encode));
-  preset.addExtPacker(0x0B, Boolean, join(packValueOf, encode));
-  preset.addExtPacker(0x0C, String, join(packValueOf, encode));
-  preset.addExtPacker(0x0D, Date, join(Number, encode));
-  preset.addExtPacker(0x0F, Number, join(packValueOf, encode));
+  preset.addExtPacker(0x0A, RegExp, [packRegExp, encode]);
+  preset.addExtPacker(0x0B, Boolean, [packValueOf, encode]);
+  preset.addExtPacker(0x0C, String, [packValueOf, encode]);
+  preset.addExtPacker(0x0D, Date, [Number, encode]);
+  preset.addExtPacker(0x0F, Number, [packValueOf, encode]);
 
-  preset.addExtUnpacker(0x0A, join(decode, unpackRegExp));
-  preset.addExtUnpacker(0x0B, join(decode, unpackClass(Boolean)));
-  preset.addExtUnpacker(0x0C, join(decode, unpackClass(String)));
-  preset.addExtUnpacker(0x0D, join(decode, unpackClass(Date)));
-  preset.addExtUnpacker(0x0F, join(decode, unpackClass(Number)));
+  preset.addExtUnpacker(0x0A, [decode, unpackRegExp]);
+  preset.addExtUnpacker(0x0B, [decode, unpackClass(Boolean)]);
+  preset.addExtUnpacker(0x0C, [decode, unpackClass(String)]);
+  preset.addExtUnpacker(0x0D, [decode, unpackClass(Date)]);
+  preset.addExtUnpacker(0x0F, [decode, unpackClass(Number)]);
 
   if ("undefined" !== typeof Uint8Array) {
     preset.addExtPacker(0x11, Int8Array, packBuffer);
@@ -51,16 +51,16 @@ function init() {
 
     preset.addExtUnpacker(0x11, unpackClass(Int8Array));
     preset.addExtUnpacker(0x12, unpackClass(Uint8Array));
-    preset.addExtUnpacker(0x13, join(unpackArrayBuffer, unpackClass(Int16Array)));
-    preset.addExtUnpacker(0x14, join(unpackArrayBuffer, unpackClass(Uint16Array)));
-    preset.addExtUnpacker(0x15, join(unpackArrayBuffer, unpackClass(Int32Array)));
-    preset.addExtUnpacker(0x16, join(unpackArrayBuffer, unpackClass(Uint32Array)));
-    preset.addExtUnpacker(0x17, join(unpackArrayBuffer, unpackClass(Float32Array)));
+    preset.addExtUnpacker(0x13, [unpackArrayBuffer, unpackClass(Int16Array)]);
+    preset.addExtUnpacker(0x14, [unpackArrayBuffer, unpackClass(Uint16Array)]);
+    preset.addExtUnpacker(0x15, [unpackArrayBuffer, unpackClass(Int32Array)]);
+    preset.addExtUnpacker(0x16, [unpackArrayBuffer, unpackClass(Uint32Array)]);
+    preset.addExtUnpacker(0x17, [unpackArrayBuffer, unpackClass(Float32Array)]);
 
     if ("undefined" !== typeof Float64Array) {
       // PhantomJS/1.9.7 doesn't have Float64Array
       preset.addExtPacker(0x18, Float64Array, packTypedArray);
-      preset.addExtUnpacker(0x18, join(unpackArrayBuffer, unpackClass(Float64Array)));
+      preset.addExtUnpacker(0x18, [unpackArrayBuffer, unpackClass(Float64Array)]);
     }
 
     if ("undefined" !== typeof Uint8ClampedArray) {
@@ -72,19 +72,7 @@ function init() {
     preset.addExtPacker(0x1A, ArrayBuffer, packArrayBuffer);
     preset.addExtPacker(0x1D, DataView, packTypedArray);
     preset.addExtUnpacker(0x1A, unpackArrayBuffer);
-    preset.addExtUnpacker(0x1D, join(unpackArrayBuffer, unpackClass(DataView)));
-  }
-}
-
-function join(filters) {
-  filters = Array.prototype.slice.call(arguments);
-
-  return function(value) {
-    return filters.reduce(iterator, value);
-  };
-
-  function iterator(value, filter) {
-    return filter(value);
+    preset.addExtUnpacker(0x1D, [unpackArrayBuffer, unpackClass(DataView)]);
   }
 }
 

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -1,8 +1,10 @@
 // ext-codec.js
 
 exports.Ext = Ext;
+exports.createCodec = createCodec;
 
 var ExtBuffer = require("./ext-buffer").ExtBuffer;
+var IS_ARRAY = require('./is-array');
 
 function Ext() {
   if (!(this instanceof Ext)) return new Ext();
@@ -10,7 +12,14 @@ function Ext() {
   this.extUnpackers = [];
 }
 
+function createCodec() {
+  return new Ext();
+}
+
 Ext.prototype.addExtPacker = function(etype, Class, packer) {
+  if (IS_ARRAY(packer)) {
+    packer = join(packer);
+  }
   var name = Class.name;
   if (name && name !== "Object") {
     this.extPackers[name] = extPacker;
@@ -26,7 +35,7 @@ Ext.prototype.addExtPacker = function(etype, Class, packer) {
 };
 
 Ext.prototype.addExtUnpacker = function(etype, unpacker) {
-  this.extUnpackers[etype] = unpacker;
+  this.extUnpackers[etype] = IS_ARRAY(unpacker) ? join(unpacker) : unpacker;
 };
 
 Ext.prototype.getExtPacker = function(value) {
@@ -49,3 +58,15 @@ Ext.prototype.getExtUnpacker = function(type) {
     return new ExtBuffer(buffer, type);
   }
 };
+
+function join(filters) {
+  filters = filters.slice();
+
+  return function(value) {
+    return filters.reduce(iterator, value);
+  };
+
+  function iterator(value, filter) {
+    return filter(value);
+  }
+}

--- a/lib/is-array.js
+++ b/lib/is-array.js
@@ -1,0 +1,3 @@
+module.exports = Array.isArray || function (array) {
+  return "[object Array]" === Object.prototype.toString.call(array);
+};

--- a/lib/read-format.js
+++ b/lib/read-format.js
@@ -20,7 +20,6 @@ exports.format = {
 
 var BufferLite = require("./buffer-lite");
 var decode = require("./read-core").decode;
-var codec = require("./ext-preset").preset;
 var BUFFER_SHORTAGE = require("./common").BUFFER_SHORTAGE;
 
 var IS_BUFFER_SHIM = ("TYPED_ARRAY_SUPPORT" in Buffer);
@@ -74,7 +73,7 @@ function ext(decoder, len) {
   var end = decoder.offset = start + len + 1;
   if (end > decoder.buffer.length) throw BUFFER_SHORTAGE;
   var type = decoder.buffer[start];
-  var unpack = codec.getExtUnpacker(type);
+  var unpack = decoder.codec.getExtUnpacker(type);
   if (!unpack) throw new Error("Invalid ext type: " + (type ? ("0x" + type.toString(16)) : type));
   var buf = decoder.buffer.slice(start + 1, end);
   return unpack(buf);

--- a/lib/write-type.js
+++ b/lib/write-type.js
@@ -17,7 +17,7 @@ var uint8 = require("./write-uint8").uint8;
 var ExtBuffer = require("./ext-buffer").ExtBuffer;
 
 var IS_BUFFER_SHIM = ("TYPED_ARRAY_SUPPORT" in Buffer);
-var IS_ARRAY = Array.isArray || isArray;
+var IS_ARRAY = require('./is-array');
 
 function bool(encoder, value) {
   // false -- 0xc2
@@ -170,8 +170,4 @@ function map(encoder, value) {
     encode(encoder, key);
     encode(encoder, value[key]);
   });
-}
-
-function isArray(array) {
-  return "[object Array]" === Object.prototype.toString.call(array);
 }

--- a/lib/write-type.js
+++ b/lib/write-type.js
@@ -14,7 +14,6 @@ var BufferLite = require("./buffer-lite");
 var token = require("./write-token").token;
 var encode = require("./write-core").encode;
 var uint8 = require("./write-uint8").uint8;
-var codec = require("./ext-preset").preset;
 var ExtBuffer = require("./ext-buffer").ExtBuffer;
 
 var IS_BUFFER_SHIM = ("TYPED_ARRAY_SUPPORT" in Buffer);
@@ -107,7 +106,7 @@ extmap[16] = 0xd8;
 function object(encoder, value) {
   if (IS_ARRAY(value)) return array(encoder, value);
   if (value === null) return nil(encoder, value);
-  var packer = codec.getExtPacker(value);
+  var packer = encoder.codec.getExtPacker(value);
   if (packer) value = packer(value);
   if (value instanceof ExtBuffer) return ext(encoder, value);
   if (Buffer.isBuffer(value)) return bin(encoder, value);


### PR DESCRIPTION
With this pull request, you can:
```javascript
var codec = msgpack.createCodec();
codec.addExtPacker(0x01, MyClass, myClassPacker);
codec.addExtUnpacker(0x01, myClassUnpacker);
msgpack.encode(data, {codec: codec});
```

And you can:
```javascript
var preset = msgpack.codec.preset;
preset.addExtPacker(0x1E, MyClass, myClassPacker);
preset.addExtUnpacker(0x1E, myClassUnpacker);
msgpack.encode(data, {codec: preset});
```

And the preset is still used by default, so there are no breaking changes.
These two are equivalent:
```javascript
msgpack.encode(data, {codec: msgpack.codec.preset});
msgpack.encode(data);
```

Lastly, you can implicitly join packers/unpackers together:
```javascript
var codec = msgpack.createCodec();
codec.addExtPacker(0x01, Date, [Number, msgpack.encode]);
codec.addExtUnpacker(0x01, [msgpack.decode, construct(Date)]);
function construct(Class) {
  return function (value) {
    return new Class(value);
  }
}
```