### PR TITLE
int/float array serialization problem

### DIFF
--- a/test/64.int-array.js
+++ b/test/64.int-array.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env mocha -R spec
+
+var assert = require("assert");
+var msgpack = require("../index");
+
+var TITLE = __filename.replace(/^.*\//, "");
+
+describe(TITLE, function() {
+  it("encode", function() {
+    var data = [ 298080447363 ];
+    var encoded = msgpack.encode(data);
+    var expected = new Buffer([0x91, 0xcf, 0x00, 0x00, 0x00, 0x45, 0x66, 0xfa, 0xab, 0x83]);
+    // msgpack-lite serializes as floats <Buffer 91 cb 42 51 59 be aa e0 c0 00>    
+    assert.equal(new Array(expected), new Array(encoded));
+  });
+});


### PR DESCRIPTION
When I try to serialize [298080447363] with msgpack-lite it serializes it as floats
`<Buffer 91 cb 42 51 59 be aa e0 c0 00>`
And I fail to unpack it on java side.
```
org.msgpack.core.MessageTypeException: Expected Integer, but got Float (cb)
	at org.msgpack.core.MessageUnpacker.unexpected(MessageUnpacker.java:580)
	at org.msgpack.core.MessageUnpacker.unpackLong(MessageUnpacker.java:927)

```
I switched to msgpack5 in my project and it serializes the same array as
`<Buffer 91 cf 00 00 00 45 66 fa ab 83>`
The PR contains a small sample to demonstrate my problem.
Is it bug or expected behavior? Am I missing something? Thanks.