### PR TITLE
export ExtBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,3 +11,5 @@ exports.createDecodeStream = require("./lib/decode-stream").createDecodeStream;
 
 exports.createCodec = require("./lib/ext").createCodec;
 exports.codec = require("./lib/codec").codec;
+
+exports.ExtBuffer = require("./lib/ext-buffer").ExtBuffer;

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -8,3 +8,5 @@ exports.Decoder = require("./decoder").Decoder;
 
 exports.createCodec = require("./ext").createCodec;
 exports.codec = require("./codec").codec;
+
+exports.ExtBuffer = require("./ext-buffer").ExtBuffer;


### PR DESCRIPTION
Hi kawanet,

All this change does is add ExtBuffer to the module exports.  I have a project that's currently using this workaround:

```js
var ExtBuffer = msgpack.decode([0xd4, 0, 0]).constructor;
```

...to enable me to manually create ExtBuffer objects for encoding.  The `addExtPacker` functionality won't work for me because I may have an unknown number of subclasses with different `constructor.name` properties.

I'd be fine with leaving ExtBuffer undocumented, or documenting it with a 'use at your own risk' warning.

Thanks!
Bart