### PR TITLE
Add option to exclude function properties when encoding objects

### DIFF
--- a/lib/write-type.js
+++ b/lib/write-type.js
@@ -26,6 +26,7 @@ exports.getWriteType = getWriteType;
 function getWriteType(options) {
   var token = WriteToken.getWriteToken(options);
   var useraw = options && options.useraw;
+  var functions = options && options.functions;
   var binarraybuffer = HAS_UINT8ARRAY && options && options.binarraybuffer;
   var isBuffer = binarraybuffer ? Bufferish.isArrayBuffer : Bufferish.isBuffer;
   var bin = binarraybuffer ? bin_arraybuffer : bin_buffer;
@@ -229,6 +230,10 @@ function getWriteType(options) {
   // map 32 -- 0xdf
   function obj_to_map(encoder, value) {
     var keys = Object.keys(value);
+
+    if (!functions)
+      keys = keys.filter(function(key) { return !(value[key] instanceof Function); });
+
     var length = keys.length;
     var type = (length < 16) ? (0x80 + length) : (length <= 0xFFFF) ? 0xde : 0xdf;
     token[type](encoder, length);

--- a/test/28.functions.js
+++ b/test/28.functions.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env mocha -R spec
+
+var assert = require("assert");
+var msgpackJS = "../index";
+var isBrowser = ("undefined" !== typeof window);
+var msgpack = isBrowser && window.msgpack || require(msgpackJS);
+var TITLE = __filename.replace(/^.*\//, "");
+var obj = {func: function() {}};
+
+describe(TITLE, function() {
+  it("functions: false", function() {
+    var options = {codec: msgpack.createCodec({functions: false})};
+
+    // as default
+    assert.deepEqual(msgpack.decode(msgpack.encode(obj)), {});
+
+    // explicit
+    assert.deepEqual(msgpack.decode(msgpack.encode(obj, options)), {});
+  });
+
+  it("functions: true", function() {
+    var options = {codec: msgpack.createCodec({functions: true})};
+
+    assert.deepEqual(msgpack.decode(msgpack.encode(obj, options)), {"func": null});
+  });
+});


### PR DESCRIPTION
The behavior of `JSON.stringify` is to exclude properties on an object that store a function:

```js
JSON.stringify({ f: function(){} }) // '{}'
```

Current behavior of `msgpack-lite`:

```js
msgpack.decode(msgpack.encode({ f: function(){} })) // { f: null }
```

Behavior this PR introduces - **excluding functions is the new default**:

```js
var obj = { f: function(){} }

msgpack.decode(msgpack.encode(obj)) // {}

// To get the old behavior
var codec = msgpack.createCodec({functions: true})
msgpack.decode(msgpack.encode(obj, {codec: codec})) // { f: null }
```

## Justification

The behavior of JSON is convenient for me, because when prototyping ideas, I often serialize whole ES6 class instances without explicitly picking properties (I'm lazy). `msgpack-lite` already excludes the class prototype's functions since it uses `Object.keys` to encode objects, but functions set as properties on the object (like functions that are bound using the common idiom in the constructor) will remain.

```js
class Foo {
  constructor() {
    this.someProp = 123
    this.boundFunc = this.boundFunc.bind(this)
  }

  someFunc() {
    return "hello"
  }

  boundFunc() {
    return this
  }
}

msgpack.decode(msgpack.encode(new Foo())) // { someProp: 123, boundFunc: null }
```

`boundFunc` would be sent over the wire as `null` and is of no benefit.

That said, I realize someone out there might have actually added a custom encoder for functions, so excluding them by default is maybe not the right solution. 100% open to discussing and making any adjustments necessary.

An alternative idea may be a codec option which allows you to exclude certain types from serialization.