### PR TITLE
Fix uint32 bug

### DIFF
--- a/lib/write-type.js
+++ b/lib/write-type.js
@@ -71,7 +71,7 @@ function getWriteType(options) {
         // int 8 -- 0xd0
         // int 16 -- 0xd1
         // int 32 -- 0xd2
-        type = (-0x80 <= value) ? 0xd0 : (-0x8000 <= value) ? 0xd1 : 0xd2;
+        type = (-0x80 <= value) ? 0xd0 : (-0x8000 <= value) ? 0xd1 : (-2147483648 <= value) ? 0xd2 : 0xcb;
       }
       token[type](encoder, value);
     } else {

--- a/lib/write-type.js
+++ b/lib/write-type.js
@@ -51,30 +51,34 @@ function getWriteType(options) {
     token[type](encoder, value);
   }
 
+  function isInt(n){
+    return Number(n) === n && n % 1 === 0;
+  }
+
   function number(encoder, value) {
-    var ivalue = value | 0;
     var type;
-    if (value !== ivalue) {
+    if (isInt(value)) {
+      if (-0x20 <= value && value <= 0x7F) {
+        // positive fixint -- 0x00 - 0x7f
+        // negative fixint -- 0xe0 - 0xff
+        type = value & 0xFF;
+      } else if (0 <= value) {
+        // uint 8 -- 0xcc
+        // uint 16 -- 0xcd
+        // uint 32 -- 0xce
+        type = (value <= 0xFF) ? 0xcc : (value <= 0xFFFF) ? 0xcd : 0xce;
+      } else {
+        // int 8 -- 0xd0
+        // int 16 -- 0xd1
+        // int 32 -- 0xd2
+        type = (-0x80 <= value) ? 0xd0 : (-0x8000 <= value) ? 0xd1 : 0xd2;
+      }
+      token[type](encoder, value);
+    } else {
       // float 64 -- 0xcb
       type = 0xcb;
       token[type](encoder, value);
-      return;
-    } else if (-0x20 <= ivalue && ivalue <= 0x7F) {
-      // positive fixint -- 0x00 - 0x7f
-      // negative fixint -- 0xe0 - 0xff
-      type = ivalue & 0xFF;
-    } else if (0 <= ivalue) {
-      // uint 8 -- 0xcc
-      // uint 16 -- 0xcd
-      // uint 32 -- 0xce
-      type = (ivalue <= 0xFF) ? 0xcc : (ivalue <= 0xFFFF) ? 0xcd : 0xce;
-    } else {
-      // int 8 -- 0xd0
-      // int 16 -- 0xd1
-      // int 32 -- 0xd2
-      type = (-0x80 <= ivalue) ? 0xd0 : (-0x8000 <= ivalue) ? 0xd1 : 0xd2;
     }
-    token[type](encoder, ivalue);
   }
 
   // uint 64 -- 0xcf

--- a/lib/write-type.js
+++ b/lib/write-type.js
@@ -51,34 +51,29 @@ function getWriteType(options) {
     token[type](encoder, value);
   }
 
-  function isInt(n){
-    return Number(n) === n && n % 1 === 0;
-  }
-
   function number(encoder, value) {
     var type;
-    if (isInt(value)) {
-      if (-0x20 <= value && value <= 0x7F) {
-        // positive fixint -- 0x00 - 0x7f
-        // negative fixint -- 0xe0 - 0xff
-        type = value & 0xFF;
-      } else if (0 <= value) {
-        // uint 8 -- 0xcc
-        // uint 16 -- 0xcd
-        // uint 32 -- 0xce
-        type = (value <= 0xFF) ? 0xcc : (value <= 0xFFFF) ? 0xcd : 0xce;
-      } else {
-        // int 8 -- 0xd0
-        // int 16 -- 0xd1
-        // int 32 -- 0xd2
-        type = (-0x80 <= value) ? 0xd0 : (-0x8000 <= value) ? 0xd1 : (-2147483648 <= value) ? 0xd2 : 0xcb;
-      }
-      token[type](encoder, value);
-    } else {
+    if (Math.floor(value) != value) {
       // float 64 -- 0xcb
       type = 0xcb;
       token[type](encoder, value);
+      return;
+    } else if (-0x20 <= value && value <= 0x7F) {
+      // positive fixint -- 0x00 - 0x7f
+      // negative fixint -- 0xe0 - 0xff
+      type = value & 0xFF;
+    } else if (0 <= value) {
+      // uint 8 -- 0xcc
+      // uint 16 -- 0xcd
+      // uint 32 -- 0xce
+      type = (value <= 0xFF) ? 0xcc : (value <= 0xFFFF) ? 0xcd : (value <= 0xFFFFFFFF) ? 0xce : 0xcf;
+    } else {
+      // int 8 -- 0xd0
+      // int 16 -- 0xd1
+      // int 32 -- 0xd2
+      type = (-0x80 <= value) ? 0xd0 : (-0x8000 <= value) ? 0xd1 : (-0x80000000 <= value) ? 0xd2 : 0xd3;
     }
+    token[type](encoder, value);
   }
 
   // uint 64 -- 0xcf


### PR DESCRIPTION
That float verification operation is wrong when the value larger than int32max
```
ivalue = value | 0;
```